### PR TITLE
Add ingresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,22 @@ helm -n default install helicone -f values.example.yaml .
 The first deployment can take some time to complete (especially auth service). You can view the status of the pods using:
 
 ```bash
-kubectl -n default get pod 
+k get pods -n default 
 
-NAME                                      READY   STATUS    RESTARTS      AGE
-demo-supabase-auth-78547c5c8d-chkbm       1/1     Running   2 (40s ago)   47s
-demo-supabase-db-5bc75fbf56-4cxcv         1/1     Running   0             47s
-demo-supabase-kong-8c666695f-5vzwt        1/1     Running   0             47s
-demo-supabase-meta-6779677c7-s77qq        1/1     Running   0             47s
-demo-supabase-realtime-6b55986d7d-csnr7   1/1     Running   0             47s
-demo-supabase-rest-5d864469d-bk5rv        1/1     Running   0             47s
-demo-supabase-storage-6c878dcbd4-zzzcv    1/1     Running   0             47s
+NAME                                                 READY   STATUS    RESTARTS   AGE
+helicone-helicone-auth-547598f79f-rmz5w              1/1     Running   0          45s
+helicone-helicone-clickhouse-6788f7f8db-5rzm4        1/1     Running   0          45s
+helicone-helicone-db-58cdcbd846-bsv9t                1/1     Running   0          45s
+helicone-helicone-functions-779d46964-ztvmc          1/1     Running   0          45s
+helicone-helicone-helicone-web-766c5b47c-9xjx7       1/1     Running   0          45s
+helicone-helicone-helicone-worker-84978c8c8b-nznnl   1/1     Running   0          45s
+helicone-helicone-imgproxy-59bf8f64b9-h479n          1/1     Running   0          45s
+helicone-helicone-kong-7df4bf4f74-z6kfp              1/1     Running   0          45s
+helicone-helicone-meta-7fc4bb6ff9-mxs7c              1/1     Running   0          45s
+helicone-helicone-realtime-74449ff776-4xm9t          1/1     Running   0          45s
+helicone-helicone-rest-645b58894b-6nqld              1/1     Running   0          45s
+helicone-helicone-storage-76f6879895-8cxwb           1/1     Running   0          45s
+helicone-helicone-studio-7b6756bd69-wfzkx            1/1     Running   0          45s
 ```
 
 ### Tunnel with Minikube
@@ -97,12 +103,13 @@ If you just use the `value.example.yaml` file, you can access the API or the Stu
 
 ```Bash
 # Uninstall Helm chart
-helm -n default uninstall demo 
+helm -n default uninstall helicone 
 
 # Delete secrets
-kubectl -n default delete secret demo-supabase-db
-kubectl -n default delete secret demo-supabase-jwt
-kubectl -n default delete secret demo-supabase-smtp
+kubectl -n default delete secret helicone-supabase
+kubectl -n default delete secret helicone-smtp
+kubectl -n default delete secret helicone-postgres
+kubectl -n default delete secret helicone-clickhouse
 ```
 
 ## Customize

--- a/helm/helicone/templates/kong/ingress.yaml
+++ b/helm/helicone/templates/kong/ingress.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.kong.enabled -}}
+{{- if .Values.kong.ingress.enabled -}}
+{{- if and .Values.kong.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.kong.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.kong.ingress.annotations "kubernetes.io/ingress.class" .Values.kong.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "supabase.kong.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.kong.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.kong.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.kong.ingress.className }}
+  {{- end }}
+  {{- if .Values.kong.ingress.tls }}
+  tls:
+    {{- range .Values.kong.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.kong.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "supabase.kong.fullname" . }}
+                port:
+                  number: {{ .Values.kong.service.port }}
+              {{- else }}
+              serviceName: {{ include "supabase.kong.fullname" . }}
+              servicePort: {{ .Values.kong.service.port }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/helicone/templates/kong/ingress.yaml
+++ b/helm/helicone/templates/kong/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.kong.enabled -}}
 {{- if .Values.kong.ingress.enabled -}}
+{{- $fullName := include "supabase.kong.fullname" . -}}
+{{- $svcPort := .Values.kong.service.httpPort -}}
 {{- if and .Values.kong.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.kong.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.kong.ingress.annotations "kubernetes.io/ingress.class" .Values.kong.ingress.className}}
@@ -8,7 +10,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "supabase.kong.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "helicone.labels" . | nindent 4 }}
   {{- with .Values.kong.ingress.annotations }}
@@ -42,12 +44,12 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ include "supabase.kong.fullname" . }}
+                name: {{ $fullName }}
                 port:
-                  number: {{ .Values.kong.service.port }}
+                  number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ include "supabase.kong.fullname" . }}
-              servicePort: {{ .Values.kong.service.port }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}
     {{- end }}

--- a/helm/helicone/templates/kong/ingress.yaml
+++ b/helm/helicone/templates/kong/ingress.yaml
@@ -10,7 +10,7 @@ kind: Ingress
 metadata:
   name: {{ include "supabase.kong.fullname" . }}
   labels:
-    {{- include "supabase.labels" . | nindent 4 }}
+    {{- include "helicone.labels" . | nindent 4 }}
   {{- with .Values.kong.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/helicone/templates/studio/ingress.yaml
+++ b/helm/helicone/templates/studio/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.studio.enabled -}}
 {{- if .Values.studio.ingress.enabled -}}
+{{- $fullName := include "supabase.studio.fullname" . -}}
+{{- $svcPort := .Values.studio.service.port -}}
 {{- if and .Values.studio.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.studio.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.studio.ingress.annotations "kubernetes.io/ingress.class" .Values.studio.ingress.className}}
@@ -8,7 +10,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "supabase.studio.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "helicone.labels" . | nindent 4 }}
   {{- with .Values.studio.ingress.annotations }}
@@ -42,12 +44,12 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ include "supabase.studio.fullname" . }}
+                name: {{ $fullName }}
                 port:
-                  number: {{ .Values.studio.service.port }}
+                  number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ include "supabase.studio.fullname" . }}
-              servicePort: {{ .Values.studio.service.port }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}
     {{- end }}

--- a/helm/helicone/templates/studio/ingress.yaml
+++ b/helm/helicone/templates/studio/ingress.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.studio.enabled -}}
+{{- if .Values.studio.ingress.enabled -}}
+{{- if and .Values.studio.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.studio.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.studio.ingress.annotations "kubernetes.io/ingress.class" .Values.studio.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "supabase.studio.fullname" . }}
+  labels:
+    {{- include "helicone.labels" . | nindent 4 }}
+  {{- with .Values.studio.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.studio.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.studio.ingress.className }}
+  {{- end }}
+  {{- if .Values.studio.ingress.tls }}
+  tls:
+    {{- range .Values.studio.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.studio.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "supabase.studio.fullname" . }}
+                port:
+                  number: {{ .Values.studio.service.port }}
+              {{- else }}
+              serviceName: {{ include "supabase.studio.fullname" . }}
+              servicePort: {{ .Values.studio.service.port }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/helicone/templates/web/ingress.yaml
+++ b/helm/helicone/templates/web/ingress.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.helicone.web.ingress.enabled -}}
+{{- $fullName := include "helicone.web.fullname" . -}}
+{{- $svcPort := .Values.helicone.web.service.port -}}
 {{- if and .Values.helicone.web.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.helicone.web.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.helicone.web.ingress.annotations "kubernetes.io/ingress.class" .Values.helicone.web.ingress.className}}
@@ -7,7 +9,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "helicone.web.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "helicone.labels" . | nindent 4 }}
   {{- with .Values.helicone.web.ingress.annotations }}
@@ -41,14 +43,13 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ include "helicone.web.fullname" . }}
+                name: {{ $fullName }}
                 port:
-                  number: {{ .Values.helicone.web.service.port }}
+                  number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ include "helicone.web.fullname" . }}
-              servicePort: {{ .Values.helicone.web.service.port }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}
     {{- end }}
-{{- end }}
 {{- end }}

--- a/helm/helicone/templates/web/ingress.yaml
+++ b/helm/helicone/templates/web/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.helicone.web.ingress.enabled -}}
+{{- if and .Values.helicone.web.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.helicone.web.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.helicone.web.ingress.annotations "kubernetes.io/ingress.class" .Values.helicone.web.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "helicone.web.fullname" . }}
+  labels:
+    {{- include "helicone.labels" . | nindent 4 }}
+  {{- with .Values.helicone.web.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.helicone.web.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.helicone.web.ingress.className }}
+  {{- end }}
+  {{- if .Values.helicone.web.ingress.tls }}
+  tls:
+    {{- range .Values.helicone.web.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.helicone.web.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "helicone.web.fullname" . }}
+                port:
+                  number: {{ .Values.helicone.web.service.port }}
+              {{- else }}
+              serviceName: {{ include "helicone.web.fullname" . }}
+              servicePort: {{ .Values.helicone.web.service.port }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/helicone/templates/worker/ingress.yaml
+++ b/helm/helicone/templates/worker/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.helicone.worker.ingress.enabled -}}
+{{- if and .Values.helicone.worker.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.helicone.worker.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.helicone.worker.ingress.annotations "kubernetes.io/ingress.class" .Values.helicone.worker.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "helicone.worker.fullname" . }}
+  labels:
+    {{- include "helicone.labels" . | nindent 4 }}
+  {{- with .Values.helicone.worker.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.helicone.worker.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.helicone.worker.ingress.className }}
+  {{- end }}
+  {{- if .Values.helicone.worker.ingress.tls }}
+  tls:
+    {{- range .Values.helicone.worker.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.helicone.worker.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "helicone.worker.fullname" . }}
+                port:
+                  number: {{ .Values.helicone.worker.service.port }}
+              {{- else }}
+              serviceName: {{ include "helicone.worker.fullname" . }}
+              servicePort: {{ .Values.helicone.worker.service.port }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/helicone/templates/worker/ingress.yaml
+++ b/helm/helicone/templates/worker/ingress.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.helicone.worker.ingress.enabled -}}
+{{- $fullName := include "helicone.worker.fullname" . -}}
+{{- $svcPort := .Values.helicone.worker.service.port -}}
 {{- if and .Values.helicone.worker.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.helicone.worker.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.helicone.worker.ingress.annotations "kubernetes.io/ingress.class" .Values.helicone.worker.ingress.className}}
@@ -7,7 +9,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "helicone.worker.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "helicone.labels" . | nindent 4 }}
   {{- with .Values.helicone.worker.ingress.annotations }}
@@ -41,14 +43,13 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ include "helicone.worker.fullname" . }}
+                name: {{ $fullName }}
                 port:
-                  number: {{ .Values.helicone.worker.service.port }}
+                  number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ include "helicone.worker.fullname" . }}
-              servicePort: {{ .Values.helicone.worker.service.port }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}
     {{- end }}
-{{- end }}
 {{- end }}

--- a/helm/helicone/values.example.yaml
+++ b/helm/helicone/values.example.yaml
@@ -107,17 +107,23 @@ studio:
     STUDIO_PG_META_URL: 'http://{{ include "supabase.meta.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8080'
     DEFAULT_ORGANIZATION_NAME: "Default Organization"
     DEFAULT_PROJECT_NAME: "Default Project"
-  # volumeMounts:
-  #   - name: volume_name
-  #     mountPath: /path/to/my/secret
-  # volumes:
-  #   - name: volume_name
-  #     secret:
-  #       defaultMode: 733
-  #       secretName: my_secret
-  #       items:
-  #       - key: my_secret.txt
-  #         path: name_of_file_in_container.txt
+  ingress:
+    enabled: true
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /
+    tls: []
+      # - secretName: studio.localhost
+      #   hosts:
+      #     - studio.localhost
+    hosts:
+      - host: studio.localhost
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: api
+              servicePort: 3000
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -490,6 +496,23 @@ kong:
     KONG_PLUGINS: request-transformer,cors,key-auth,acl      
     KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
     KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
+  ingress:
+    enabled: true
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /
+    tls: []
+      # - secretName: localhost
+      #   hosts:
+      #     - localhost
+    hosts:
+      - host: localhost
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: api
+              servicePort: 80
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -596,17 +619,34 @@ helicone:
       DB_PORT: "{{ tpl .Values.database.port . }}"
       DB_DRIVER: postgres
       DB_NAME: "{{ tpl .Values.database.name . }}"
-    resources: {}
-      # We usually recommend not to specify default resources and to leave this as a conscious
-      # choice for the user. This also increases chances charts run on environments with little
-      # resources, such as Minikube. If you do want to specify resources, uncomment the following
-      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-      # limits:
-      #   cpu: 100m
-      #   memory: 128Mi
-      # requests:
-      #   cpu: 100m
-      #   memory: 128Mi
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+      tls: []
+        # - secretName: helicone.localhost
+        #   hosts:
+        #     - helicone.localhost
+      hosts:
+        - host: helicone.localhost
+          paths:
+            - path: /
+              pathType: Prefix
+              backend:
+                serviceName: api
+                servicePort: 3000
+      resources: {}
+        # We usually recommend not to specify default resources and to leave this as a conscious
+        # choice for the user. This also increases chances charts run on environments with little
+        # resources, such as Minikube. If you do want to specify resources, uncomment the following
+        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+        # limits:
+        #   cpu: 100m
+        #   memory: 128Mi
+        # requests:
+        #   cpu: 100m
+        #   memory: 128Mi
 
   worker:
     image:
@@ -622,17 +662,34 @@ helicone:
     environment:
       SUPABASE_URL: 'http://{{ include "supabase.kong.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8000'
       CLICKHOUSE_HOST: 'http://{{ include "clickhouse.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8123'
-    resources: {}
-      # We usually recommend not to specify default resources and to leave this as a conscious
-      # choice for the user. This also increases chances charts run on environments with little
-      # resources, such as Minikube. If you do want to specify resources, uncomment the following
-      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-      # limits:
-      #   cpu: 100m
-      #   memory: 128Mi
-      # requests:
-      #   cpu: 100m
-      #   memory: 128Mi
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+      tls: []
+        # - secretName: helicone-worker.localhost
+        #   hosts:
+        #     - helicone-worker.localhost
+      hosts:
+        - host: helicone-worker.localhost
+          paths:
+            - path: /
+              pathType: Prefix
+              backend:
+                serviceName: api
+                servicePort: 8787
+      resources: {}
+        # We usually recommend not to specify default resources and to leave this as a conscious
+        # choice for the user. This also increases chances charts run on environments with little
+        # resources, such as Minikube. If you do want to specify resources, uncomment the following
+        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+        # limits:
+        #   cpu: 100m
+        #   memory: 128Mi
+        # requests:
+        #   cpu: 100m
+        #   memory: 128Mi
 
 clickhouse:
   image:

--- a/helm/helicone/values.example.yaml
+++ b/helm/helicone/values.example.yaml
@@ -13,7 +13,7 @@
 # |-- 12. Clickhouse
 
 global:
-  baseDomain: EXAMPLE.COM
+  baseDomain: localhost
   
 database:
   host: '{{ include "supabase.db.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local'
@@ -506,7 +506,7 @@ kong:
       #   hosts:
       #     - localhost
     hosts:
-      - host: localhost
+      - host: supabase.localhost
         paths:
           - path: /
             pathType: Prefix


### PR DESCRIPTION
Add ingresses to work with a configured nginx ingress-controller (IC) installed in a minikube cluster. 

I installed the nginx IC via 

```
helm install -n kube-system nginx ingress-nginx --repo https://kubernetes.github.io/ingress-nginx
```

Helpful diagram on how the nginx ic works
![image](https://github.com/Helicone/helicone-helm-chart/assets/3460589/13845c9e-bdb5-41c5-a7a9-5cdb0f2b4fcb)

After setting up, you can access k8s svcs w/out port-forwarding
<img width="1247" alt="Screen Shot 2023-08-07 at 8 46 54 PM" src="https://github.com/Helicone/helicone-helm-chart/assets/3460589/afb8d30f-9407-45d6-922b-3ffbad457763">
